### PR TITLE
Material icon additions & cleanup

### DIFF
--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -973,98 +973,26 @@ border-radius: 3px;
 }
 
 .fa-eye:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"remove_red_eye"
 }
 
 .fa-trash:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"delete"
 }
 
 .fa-clock-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"access_time"
 }
 
 .fa-chevron-left:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"keyboard_arrow_left"
 }
 
 .fa-flash:before,.fa-bolt:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"flash_on"
 }
 
 .fa-plus:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"add"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2458,6 +2458,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"tag_faces"
 }
 
+.fa-mail-reply-all:before,.fa-reply-all:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"reply_all"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2331,6 +2331,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"autorenew"
 }
 
+.fa-home:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"home"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2299,6 +2299,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"filter_list"
 }
 
+.fa-shopping-bag:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"shopping_cart"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1248,7 +1248,7 @@ font: normal normal normal 16px/1 'Material Icons';
 }
 
 .fa-exchange:before {
- content:"timeline"
+ content:"compare_arrows"
 }
 
 .fa-eye-slash:before {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -949,98 +949,26 @@ border-radius: 3px;
 }
 
 .fa-envelope:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"email"
 }
 
 .fa-key:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"vpn_key"
 }
 
 .fa-puzzle-piece:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"extension"
 }
 
 .fa-paint-brush:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"format_paint"
 }
 
 .fa-file-text-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"insert_drive_file"
 }
 
 .fa-tags:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"label"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1223,6 +1223,10 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"arrow_drop_up"
 }
 
+.fa-caret-down:before {
+ content:"arrow_drop_down"
+}
+
 .fa-filter:before {
  content:"filter_list"
 }

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2395,6 +2395,37 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"remove_red_eye"
 }
 
+.fa-user-circle:before {
+    font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"account_circle"
+}
+.fa-user-circle-o:before {
+    font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"account_circle"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2171,7 +2171,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"table_chart"
 }
 
-
+.fa-video-camera:before {
+    font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"videocamera"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1295,6 +1295,13 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"lens"
 }
 
+.fa-angle-double-up:before {
+ content:"arrow_upward"
+}
+.fa-angle-double-down:before {
+ content:"arrow_downward"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2091,6 +2091,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"flag"
 }
 
+.fa-italic:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"format_italic"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2219,6 +2219,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"all_out"
 }
 
+.fa-columns:before {
+    font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"view_column"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2442,6 +2442,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"check_circle"
 }
 
+.fa-smile-o:before {
+    font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"tag_faces"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2107,6 +2107,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"format_italic"
 }
 
+.fa-paste:before,.fa-clipboard:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"wallpaper"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2203,6 +2203,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"forum"
 }
 
+.fa-circle-o:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"all_out"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1979,7 +1979,21 @@ font: normal normal normal 16px/1 'Material Icons';
   content:"comment";
 }
 
-
+.fa-play:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"play_arrow"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2347,6 +2347,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"home"
 }
 
+.fa-map-marker:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"place"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1291,6 +1291,10 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"rss_feed"
 }
 
+.fa-circle:before {
+ content:"lens"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1048,253 +1048,66 @@ font: normal normal normal 16px/1 'Material Icons';
 }
 
 .fa-ellipsis-v:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"more_vert"
 }
 
 .fa-drivers-license-o:before,.fa-id-card-o:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"perm_identity"
 }
 
  .unread .DiscussionListItem-count:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display:inline-block;
-  font-size:inherit;
-  text-rendering:auto;
-  -webkit-font-smoothing:antialiased;
-  -moz-osx-font-smoothing:grayscale;
-  float:left;
-  margin-left:-21px;
-  margin-top:3px;
   content:"chat_bubble"
  }
 
  .DiscussionListItem-count:before {
-  display:inline-block;
-  font: normal normal normal 16px/1 'Material Icons';
-  font-size:inherit;
-  text-rendering:auto;
-  -webkit-font-smoothing:antialiased;
-  -moz-osx-font-smoothing:grayscale;
-  float:left;
-  margin-left:-21px;
-  margin-top:3px;
  content:"chat_bubble_outline";
  }
 
 .fa-photo:before,.fa-image:before,.fa-picture-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"photo"
 }
 
 .fa-line-chart:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"timeline"
 }
 
 .fa-film:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"movie"
 }
 
 .fa-bold:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"format_bold"
 }
 
 .fa-minus:before {
-    font: normal normal normal 16px/1 'Material Icons';
-    display: inline-block;
-    transform: translateY(10%);
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    -moz-osx-font-smoothing: grayscale;
-    font-feature-settings: 'liga';
     content: "minimize";
 }
 
 .Composer-controls .fa-minus:before {
-    font: normal normal normal 16px/1 'Material Icons';
-    display: inline-block;
-    transform: translateY(10%);
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    -moz-osx-font-smoothing: grayscale;
-    font-feature-settings: 'liga';
     content: "minimize";
 }
 
 .fa-minus-square:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"minimize"
 }
 
 .fa-address-book-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"contacts"
 }
 
 .fa-money:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"money"
 }
 
 .fa-crop:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"crop"
 }
 
 .fa-language:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"language"
 }
 
 .fa-thumbs-up:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"thumb_up"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -829,7 +829,7 @@ border-radius: 3px;
 
 /* Material Icons Beginning */
 
-.fa-comment-o:before {
+.fa {
   font: normal normal normal 16px/1 'Material Icons';
   display: inline-block;
   transform: translateY(10%);
@@ -842,406 +842,109 @@ border-radius: 3px;
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'liga';
+}
+
+.fa-comment-o:before {
   content:"message";
 }
 
 .fa-navicon:before,.fa-reorder:before,.fa-bars:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"format_list_bulleted"
 }
 
 .fa-at:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"alternate_email"
 }
 
 .fa-gear:before,.fa-cog:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"settings"
 }
 
 .fa-comments-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"forum"
 }
 
 .fa-star:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"star"
 }
 
 .fa-star-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"star_border"
 }
 
 .fa-flag:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"flag"
 }
 
 .fa-warning:before,.fa-exclamation-triangle:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"pan_tool"
 }
 
 .fa-trash-o:before {
- font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"delete"
 }
 
 .fa-sign-out:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"directions_run"
 }
 
 .fa-wrench:before {
-  font:normal normal normal 14px/1.2 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"build"
 }
 
 .fa-user:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"account_circle"
 }
 
 .fa-bell:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"notifications"
 }
 
 .fa-th-large:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"label"
 }
 
 .fa-pencil:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"edit"
 }
 
 .fa-code-fork:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"call_split"
 }
 
 .fa-envelope-o:before {
- font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"email"
 }
 
 .fa-thumbs-o-up:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"thumb_up"
 }
 
 .fa-thumbs-o-down:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"thumb_down"
 }
 
 .fa-lock:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"lock"
 }
 
 .fa-mail-reply:before,.fa-reply:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"reply"
 }
 
 .fa-check:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"check"
 }
 
 .fa-search:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"search"
 }
 
 .fa-remove:before,.fa-close:before,.fa-times:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"close"
 }
 
 .fa-bar-chart-o:before,.fa-bar-chart:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"dashboard"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2522,6 +2522,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"line_style"
 }
 
+.fa-exclamation:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"warning"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2363,6 +2363,23 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"place"
 }
 
+.fa-exchange:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"timeline"
+}
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2538,6 +2538,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"warning"
 }
 
+.fa-feed:before,.fa-rss:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"rss_feed"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1307,9 +1307,51 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"add_circle"
 }
 
-
-
 /* Material Icons Ending */
+
+/* Font Awesome Icons Beginning */
+
+.fa-twitter:before {
+ display:inline-block;
+ font:normal normal normal 14px/1 FontAwesome;
+ font-size:inherit;
+ text-rendering:auto;
+ -webkit-font-smoothing:antialiased;
+ -moz-osx-font-smoothing:grayscale;
+ content:"\f099"
+}
+
+.fa-youtube-play:before {
+ display:inline-block;
+ font:normal normal normal 14px/1 FontAwesome;
+ font-size:inherit;
+ text-rendering:auto;
+ -webkit-font-smoothing:antialiased;
+ -moz-osx-font-smoothing:grayscale;
+ content:"\f16a"
+}
+
+.fa-github:before {
+ display:inline-block;
+ font:normal normal normal 14px/1 FontAwesome;
+ font-size:inherit;
+ text-rendering:auto;
+ -webkit-font-smoothing:antialiased;
+ -moz-osx-font-smoothing:grayscale;
+ content:"\f09b"
+}
+
+.fa-facebook-f:before,.fa-facebook:before {
+   display:inline-block;
+ font:normal normal normal 14px/1 FontAwesome;
+ font-size:inherit;
+ text-rendering:auto;
+ -webkit-font-smoothing:antialiased;
+ -moz-osx-font-smoothing:grayscale;
+ content:"\f09a"
+}
+
+/* Font Awesome Icons Ending */
 
 .TagsLabel .TagLabel {
    border-radius:12px;

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1995,6 +1995,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"play_arrow"
 }
 
+.fa-file-photo-o:before,.fa-file-picture-o:before,.fa-file-image-o:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"collections"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2426,6 +2426,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"account_circle"
 }
 
+.fa-check-circle-o:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"check_circle"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2251,6 +2251,24 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"av_timer"
 }
 
+.fa-code:before {
+    font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"code"
+}
+
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2235,6 +2235,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"view_column"
 }
 
+.fa-dashboard:before,.fa-tachometer:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"av_timer"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1298,9 +1298,16 @@ font: normal normal normal 16px/1 'Material Icons';
 .fa-angle-double-up:before {
  content:"arrow_upward"
 }
+
 .fa-angle-double-down:before {
  content:"arrow_downward"
 }
+
+.fa-plus-circle:before {
+ content:"add_circle"
+}
+
+
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1112,162 +1112,42 @@ font: normal normal normal 16px/1 'Material Icons';
 }
 
 .fa-angle-double-right:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"subdirectory_arrow_right"
 }
 
 .fa-pencil-square:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"edit_location"
 }
 
 .fa-sticky-note:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"note"
 }
 
 .fa-refresh:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"refresh"
 }
 
 .fa-minus:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"remove"
 }
 
 .fa-expand:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"fullscreen"
 }
 
 .fa-compress:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"fullscreen_exit"
 }
 
 .fa-ellipsis-h:before {
- font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"more_horiz";
 }
 
 .fa-commenting-o:before {
-font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"comment";
 }
 
 .fa-play:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"play_arrow"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2379,6 +2379,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"timeline"
 }
 
+.fa-eye-slash:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"remove_red_eye"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2187,6 +2187,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"videocamera"
 }
 
+.fa-comments:before {
+ font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"forum"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2027,6 +2027,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"video_library"
 }
 
+.fa-times-rectangle-o:before,.fa-window-close-o:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"not_interested"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2123,6 +2123,23 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"wallpaper"
 }
 
+.fa-font:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"font_download"
+}
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -997,130 +997,34 @@ border-radius: 3px;
 }
 
 .fa-map-o:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"map"
 }
 
 .fa-edit:before,.fa-pencil-square-o:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"border_color"
 }
 
 .fa-user-plus:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"group_add"
 }
 
 .fa-group:before,.fa-users:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"group"
 }
 
 .fa-i-cursor:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"format_size"
 }
 
 .fa-thumb-tack:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"place"
 }
 
 .fa-ban:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"not_interested"
 }
 
 .fa-globe:before {
-   font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
   content:"language"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2410,21 +2410,6 @@ font: normal normal normal 16px/1 'Material Icons';
  font-feature-settings:'liga';
  content:"account_circle"
 }
-.fa-user-circle-o:before {
-    font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
- content:"account_circle"
-}
 
 .fa-check-circle-o:before {
   font:normal normal normal 16px/1 'Material Icons';

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2315,6 +2315,23 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"shopping_cart"
 }
 
+.fa-retweet:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"autorenew"
+}
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2490,6 +2490,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"share"
 }
 
+.fa-shield:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"security"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2283,6 +2283,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"arrow_drop_up"
 }
 
+.fa-filter:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"filter_list"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2139,6 +2139,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"font_download"
 }
 
+.fa-ge:before,.fa-empire:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"settings"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1216,290 +1216,74 @@ font: normal normal normal 16px/1 'Material Icons';
 }
 
 .fa-code:before {
-    font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"code"
 }
 
 .fa-toggle-up:before,.fa-caret-square-o-up:before {
-    font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"arrow_drop_up"
 }
 
 .fa-filter:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"filter_list"
 }
 
 .fa-shopping-bag:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"shopping_cart"
 }
 
 .fa-retweet:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"autorenew"
 }
 
 .fa-home:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"home"
 }
 
 .fa-map-marker:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"place"
 }
 
 .fa-exchange:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"timeline"
 }
 
 .fa-eye-slash:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"remove_red_eye"
 }
 
 .fa-user-circle:before {
-    font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"account_circle"
 }
 
 .fa-check-circle-o:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"check_circle"
 }
 
 .fa-smile-o:before {
-    font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"tag_faces"
 }
 
 .fa-mail-reply-all:before,.fa-reply-all:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"reply_all"
 }
 
 .fa-share-alt:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"share"
 }
 
 .fa-shield:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"security"
 }
 
 .fa-sitemap:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"line_style"
 }
 
 .fa-exclamation:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"warning"
 }
 
 .fa-feed:before,.fa-rss:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"rss_feed"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2043,6 +2043,39 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"not_interested"
 }
 
+.fa-vcard:before,.fa-address-card:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"video_label"
+}
+
+.fa-vcard-o:before,.fa-address-card-o:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"video_label"
+}
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1152,258 +1152,66 @@ font: normal normal normal 16px/1 'Material Icons';
 }
 
 .fa-file-photo-o:before,.fa-file-picture-o:before,.fa-file-image-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"collections"
 }
 
 .fa-file-movie-o:before,.fa-file-video-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"video_library"
 }
 
 .fa-times-rectangle-o:before,.fa-window-close-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"not_interested"
 }
 
 .fa-vcard:before,.fa-address-card:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"video_label"
 }
 
 .fa-vcard-o:before,.fa-address-card-o:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"video_label"
 }
 
 .fa-fa:before,.fa-font-awesome:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"flag"
 }
 
 .fa-italic:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"format_italic"
 }
 
 .fa-paste:before,.fa-clipboard:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"wallpaper"
 }
 
 .fa-font:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"font_download"
 }
 
 .fa-ge:before,.fa-empire:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"settings"
 }
 
 .fa-table:before {
-  font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"table_chart"
 }
 
 .fa-video-camera:before {
-    font: normal normal normal 16px/1 'Material Icons';
-  display: inline-block;
-  transform: translateY(10%);
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  font-feature-settings: 'liga';
  content:"videocamera"
 }
 
 .fa-comments:before {
- font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"forum"
 }
 
 .fa-circle-o:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"trip_origin"
 }
 
 .fa-columns:before {
-    font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"view_column"
 }
 
 .fa-dashboard:before,.fa-tachometer:before {
-  font:normal normal normal 16px/1 'Material Icons';
- display:inline-block;
- transform:translateY(10%);
- text-transform:none;
- letter-spacing:normal;
- word-wrap:normal;
- white-space:nowrap;
- direction:ltr;
- -webkit-font-smoothing:antialiased;
- text-rendering:optimizeLegibility;
- -moz-osx-font-smoothing:grayscale;
- font-feature-settings:'liga';
  content:"av_timer"
 }
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2267,7 +2267,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"code"
 }
 
-
+.fa-toggle-up:before,.fa-caret-square-o-up:before {
+    font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"arrow_drop_up"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2506,7 +2506,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"security"
 }
 
-
+.fa-sitemap:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"line_style"
+}
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -1963,6 +1963,24 @@ font: normal normal normal 16px/1 'Material Icons';
   content:"more_horiz";
 }
 
+.fa-commenting-o:before {
+font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+  content:"comment";
+}
+
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2474,6 +2474,22 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"reply_all"
 }
 
+.fa-share-alt:before {
+  font:normal normal normal 16px/1 'Material Icons';
+ display:inline-block;
+ transform:translateY(10%);
+ text-transform:none;
+ letter-spacing:normal;
+ word-wrap:normal;
+ white-space:nowrap;
+ direction:ltr;
+ -webkit-font-smoothing:antialiased;
+ text-rendering:optimizeLegibility;
+ -moz-osx-font-smoothing:grayscale;
+ font-feature-settings:'liga';
+ content:"share"
+}
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2216,7 +2216,7 @@ font: normal normal normal 16px/1 'Material Icons';
  text-rendering:optimizeLegibility;
  -moz-osx-font-smoothing:grayscale;
  font-feature-settings:'liga';
- content:"all_out"
+ content:"trip_origin"
 }
 
 .fa-columns:before {
@@ -2505,6 +2505,8 @@ font: normal normal normal 16px/1 'Material Icons';
  font-feature-settings:'liga';
  content:"security"
 }
+
+
 
 /* Material Icons Ending */
 

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2155,6 +2155,24 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"settings"
 }
 
+.fa-table:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"table_chart"
+}
+
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2011,6 +2011,23 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"collections"
 }
 
+.fa-file-movie-o:before,.fa-file-video-o:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"video_library"
+}
+
+
 /* Material Icons Ending */
 
 .TagsLabel .TagLabel {

--- a/resources/less/app.less
+++ b/resources/less/app.less
@@ -2075,6 +2075,21 @@ font: normal normal normal 16px/1 'Material Icons';
  content:"video_label"
 }
 
+.fa-fa:before,.fa-font-awesome:before {
+  font: normal normal normal 16px/1 'Material Icons';
+  display: inline-block;
+  transform: translateY(10%);
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'liga';
+ content:"flag"
+}
 
 /* Material Icons Ending */
 


### PR DESCRIPTION
This PR extends the support of Material icons for a variety of extensions, prevents duplicate code for icons and adds Font Awesome icon support to unsupported Material icons (such as brand icons)