### PR TITLE
Add CSS & JS through head strings, not through other JS

### DIFF
--- a/js/admin/dist/extension.js
+++ b/js/admin/dist/extension.js
@@ -10,9 +10,7 @@ System.register('extum/flarum-ext-material/main', ['flarum/app'], function (_exp
     }],
     execute: function () {
 
-      app.initializers.add('extum/flarum-ext-material', function () {
-        //console.log('Hello, admin!');
-      });
+      app.initializers.add('extum/flarum-ext-material', function () {});
     }
   };
 });

--- a/js/admin/src/main.js
+++ b/js/admin/src/main.js
@@ -1,16 +1,3 @@
 import app from 'flarum/app';
-import {extend} from 'flarum/extend';
-import Page from 'flarum/components/Page';
 
-app.initializers.add('extum/flarum-ext-material', () => {
-  extend(Page.prototype, 'init', function () {
-        $('head').prepend('<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">' +
-                          '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/styles.css">' +
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/baseline.css">' +
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/sharp.css">' +    
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/outline.css">' +  
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/round.css">' +       
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/twotone.css">' + 
-            '<script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>');
-    });
-});
+app.initializers.add('extum/flarum-ext-material', () => {});

--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -1,31 +1,16 @@
 'use strict';
 
-System.register('extum/flarum-ext-material/main', ['flarum/app', 'flarum/extend', 'flarum/components/Page'], function (_export, _context) {
-    "use strict";
+System.register('extum/flarum-ext-material/main', ['flarum/app'], function (_export, _context) {
+  "use strict";
 
-    var app, extend, Page;
-    return {
-        setters: [function (_flarumApp) {
-            app = _flarumApp.default;
-        }, function (_flarumExtend) {
-            extend = _flarumExtend.extend;
-        }, function (_flarumComponentsPage) {
-            Page = _flarumComponentsPage.default;
-        }],
-        execute: function () {
+  var app;
+  return {
+    setters: [function (_flarumApp) {
+      app = _flarumApp.default;
+    }],
+    execute: function () {
 
-            app.initializers.add('extum/flarum-ext-material', function () {
-                extend(Page.prototype, 'init', function () {
-                    $('head').prepend('<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">' + 
-                                      '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/styles.css">' +
-                                      '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/baseline.css">' +
-                                      '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/sharp.css">' +    
-                                      '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/outline.css">' +  
-                                      '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/round.css">' +       
-                                      '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/twotone.css">' + 
-                                      '<script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>');
-                });
-            });
-        }
-    };
+      app.initializers.add('extum/flarum-ext-material', function () {});
+    }
+  };
 });

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -1,16 +1,3 @@
 import app from 'flarum/app';
-import {extend} from 'flarum/extend';
-import Page from 'flarum/components/Page';
 
-app.initializers.add('extum/flarum-ext-material', () => {
-    extend(Page.prototype, 'init', function () {
-        $('head').prepend('<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">' +
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/styles.css">' +
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/baseline.css">' +
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/sharp.css">' +    
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/outline.css">' +  
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/round.css">' +       
-            '<link rel="stylesheet" href="https://storage.googleapis.com/non-spec-apps/mio-icons/latest/twotone.css">' +      
-            '<script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>');
-    });
-});
+app.initializers.add('extum/flarum-ext-material', () => {});

--- a/src/Listeners/AddClientAssets.php
+++ b/src/Listeners/AddClientAssets.php
@@ -35,18 +35,25 @@ class AddClientAssets
     {
         if ($event->isAdmin()) {
             $event->addAssets([
-                __DIR__.'/../../js/admin/dist/extension.js',
                 __DIR__.'/../../resources/less/admin.less',
             ]);
-            $event->addBootstrapper('extum/flarum-ext-material/main');
         }
         if ($event->isForum()) {
             $event->addAssets([
-                __DIR__.'/../../js/forum/dist/extension.js',
                 __DIR__.'/../../resources/less/app.less',
             ]);
-            $event->addBootstrapper('extum/flarum-ext-material/main');
         }
+
+        $view = $event->view;
+
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/icon?family=Material+Icons\">");
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://storage.googleapis.com/non-spec-apps/mio-icons/latest/styles.css\">");
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://storage.googleapis.com/non-spec-apps/mio-icons/latest/baseline.css\">");
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://storage.googleapis.com/non-spec-apps/mio-icons/latest/sharp.css\">");
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://storage.googleapis.com/non-spec-apps/mio-icons/latest/outline.css\">");
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://storage.googleapis.com/non-spec-apps/mio-icons/latest/round.css\">");
+        $view->addHeadString("<link rel=\"stylesheet\" href=\"https://storage.googleapis.com/non-spec-apps/mio-icons/latest/twotone.css\">");
+        $view->addFootString("<script src=\"https://code.getmdl.io/1.3.0/material.min.js\"></script>");
     }
     
     /**


### PR DESCRIPTION
**Changes**

Adds the CSS & JS through head strings instead of by adding HTML to the head through JS.

**Reviewers should focus on**

Merge this as a quick-fix PR.

**More information**

In https://github.com/Extum/flarum-ext-material/pull/133, use the NPM module and import CSS & JS instead of adding HTML to the head to load more files.
See https://github.com/material-components/material-components-web and http://npmjs.com/package/material-components-web